### PR TITLE
fix compile error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 all : linux
 
 linux :
-	gcc -g -Wall --shared -o snapshot.so snapshot.c
+	gcc -g -Wall -fPIC --shared -o snapshot.so snapshot.c
 
 mingw :
 	gcc -g -Wall --shared -o snapshot.dll snapshot.c -I/usr/local/include -L/usr/local/bin -llua52


### PR DESCRIPTION
gcc -g -Wall --shared -o snapshot.so snapshot.c
/usr/bin/ld: /tmp/ccpkvzuQ.o: relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/tmp/ccpkvzuQ.o: could not read symbols: Bad value
collect2: error: ld returned 1 exit status
make: *** [linux] Error 1