### PR TITLE
Fixed compile error in msys/msys2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@ linux :
 	gcc -g -Wall -fPIC --shared -o snapshot.so snapshot.c
 
 mingw : 
-	gcc -g -Wall --shared -o snapshot.dll snapshot.c -I/usr/local/include -L/usr/local/bin -llua53
+	gcc -g -Wall --shared -o snapshot.dll snapshot.c -I/usr/local/include -L/usr/local/lib -llua53
 
 mingw51 :
-	gcc -g -Wall --shared -o snapshot.dll snapshot.c -I/usr/local/include -L/usr/local/bin -llua51
+	gcc -g -Wall --shared -o snapshot.dll snapshot.c -I/usr/local/include -L/usr/local/lib -llua51
 
 macosx :
 	gcc -g -Wall --shared -undefined dynamic_lookup -o snapshot.so snapshot.c


### PR DESCRIPTION
Administrator@MoHuSheng1802 /c/lua-snapshot-2
$ make mingw
gcc -g -Wall --shared -o snapshot.dll snapshot.c -I/usr/local/include -L/usr/loc
al/bin -llua
C:/Users/ADMINI~1/AppData/Local/Temp/ccCT9QaK.o: In function `lua_getuservalue':

/c/lua-snapshot-2/snapshot.c:37: undefined reference to `_lua_getfenv'
C:/Users/ADMINI~1/AppData/Local/Temp/ccCT9QaK.o: In function `mark_function_env'
:
/c/lua-snapshot-2/snapshot.c:42: undefined reference to `_lua_getfenv'
C:/Users/ADMINI~1/AppData/Local/Temp/ccCT9QaK.o: In function `keystring':
/c/lua-snapshot-2/snapshot.c:128: undefined reference to `_lua_tonumber'
C:/Users/ADMINI~1/AppData/Local/Temp/ccCT9QaK.o: In function `gen_table_desc':
/c/lua-snapshot-2/snapshot.c:332: undefined reference to `_luaL_prepbuffer'
C:/Users/ADMINI~1/AppData/Local/Temp/ccCT9QaK.o: In function `pdesc':
/c/lua-snapshot-2/snapshot.c:350: undefined reference to `_luaL_prepbuffer'
/c/lua-snapshot-2/snapshot.c:358: undefined reference to `_luaL_prepbuffer'
/c/lua-snapshot-2/snapshot.c:362: undefined reference to `_luaL_prepbuffer'
collect2: ld returned 1 exit status
make: *** [mingw] Error 1