### PR TITLE
fixed: readobject cause wrong stack when lua_topointer result is NULL.

### DIFF
--- a/snapshot.c
+++ b/snapshot.c
@@ -99,6 +99,12 @@ readobject(lua_State *L, lua_State *dL, const void *parent, const char *desc) {
 	}
 
 	const void * p = lua_topointer(L, -1);
+	if (p == NULL)
+	{
+		lua_pop(L, 1);
+		return NULL;
+	}
+
 	if (ismarked(dL, p)) {
 		lua_rawgetp(dL, tidx, p);
 		if (!lua_isnil(dL,-1)) {


### PR DESCRIPTION
const void * p = lua_topointer(L, -1);
当p为NULL时，ismarked判断肯定过不了，走到最后的return p。而p为空，但是没有对应的lua_pop(L），导致lua栈错乱，引发后续一系列的内存错误。